### PR TITLE
Make local-koinos work on new versions of Docker

### DIFF
--- a/bin/local-koinos
+++ b/bin/local-koinos
@@ -2,7 +2,7 @@
 
 const { program, Option } = require('commander')
 const pkg = require('../package.json')
-const { LocalKoinos } = require('../src/index')
+const { LocalKoinos } = require('../lib/index')
 
 let localKoinos
 

--- a/src/localKoinos.ts
+++ b/src/localKoinos.ts
@@ -107,7 +107,7 @@ export class LocalKoinos {
   async startNode() {
     console.log(chalk.blue(`Starting node ${this.nodeName}...\n`))
 
-    const cmd = `docker-compose -p ${this.nodeName} -f ${this.dockerComposeFile} --env-file ${this.envFile} up -d`
+    const cmd = `composecmd() { if [ -x "$(command -v docker-compose-v1)" ] ; then docker-compose-v1 "$@" ; else docker-compose "$@" ; fi ; } ; composecmd -p ${this.nodeName} -f ${this.dockerComposeFile} --env-file ${this.envFile} up -d`
     console.log(chalk.blue(cmd))
     execSync(cmd, { stdio: 'inherit' })
 
@@ -125,7 +125,7 @@ export class LocalKoinos {
       clearTimeout(this.intervalBlockProducerTimeout)
     }
 
-    const cmd = `docker-compose -p ${this.nodeName} -f ${this.dockerComposeFile} down -v`
+    const cmd = `composecmd() { if [ -x "$(command -v docker-compose-v1)" ] ; then docker-compose-v1 "$@" ; else docker-compose "$@" ; fi ; } ; composecmd -p ${this.nodeName} -f ${this.dockerComposeFile} down -v`
     console.log(chalk.blue(cmd))
     execSync(cmd, { stdio: 'inherit' })
 


### PR DESCRIPTION
The current version of local-koinos does not work out-of-the box on Macs running Docker Desktop Version
4.14.0 (91374) / Engine: 20.10.21 / Compose: v2.12.2. The docker-compose v. 2.12.2 shipped with Docker Desktop 4.14.0 does not support the "-p" command line option used by localCoinos.ts. However, Docker Desktop also installs  Docker Compose 1.29.2 as a separate "docker-compose-v1" command that does support the "-p" option. Additionally, the bin/local-koinos script tries to import the uncompiled "src/localKoinos.ts" instead of the compiled "lib/localKoinos.js", which does not work out-of-the-box. 

This pull request makes the following changes to local-koinos:

* In localCoinos.ts call  docker-compose-v1 instead of docker-compose if  docker-compose-v1 exists
* in bin/local-koinos import lib/localKoinos instead of src/localKoinos     
